### PR TITLE
Fixes

### DIFF
--- a/src/components/IconPicker/Input.tsx
+++ b/src/components/IconPicker/Input.tsx
@@ -44,12 +44,7 @@ export const IconPickerInput: React.FC<IconPickerInputProps> = (props) => {
   const { i18n, t } = useTranslation()
 
   const handleChange = (evt: ChangeEvent<HTMLInputElement>) => {
-    if (!evt.target.value.startsWith('#')) {
-      evt.target.value = `#${evt.target.value}`
-    }
-
-    evt.target.value = evt.target.value.replace(/[^a-f0-9#]/gi, '').slice(0, 7)
-
+    setSearch(evt.target.value)
     onChange?.(evt as any)
   }
 

--- a/src/components/IconPicker/index.tsx
+++ b/src/components/IconPicker/index.tsx
@@ -89,6 +89,7 @@ const IconPickerField: IconPickerFieldClientComponent = (props) => {
       style={styles}
       value={(value as string) || ''}
       icons={icons}
+      placeholder={placeholder}
     />
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export const iconPickerField = (
         Field: {
           clientProps: {
             icons: icons,
+            readOnly: rest?.admin?.readOnly,
           },
           path: '@innovixx/payload-icon-picker-field/components#IconPickerFieldComponent',
         },


### PR DESCRIPTION
Fixes placeholder and readOnly component props passing forward.
Allows main Input Field to be used as a search (and removes hexcode restriction that was previously applied)

readOnly only applies to the main input field with the rest of the functionality still working.
Possibly look into two different options:
1. Fully disable IconPicker field
2. Current functionality of only partially readOnly